### PR TITLE
Update plugin version to support 243 and 243.*

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,7 +100,7 @@ tasks {
     }
 
     patchPluginXml {
-        sinceBuild.set("242.20224.300")  // Set the minimum supported IntelliJ IDEA build
+        sinceBuild.set("243.21565.193")  // Set the minimum supported IntelliJ IDEA build
         untilBuild.set("243.*")           // Set the maximum supported IntelliJ IDEA build
     }
 }

--- a/src/main/java/com/contrastsecurity/plugin/inspection/Action.java
+++ b/src/main/java/com/contrastsecurity/plugin/inspection/Action.java
@@ -11,6 +11,8 @@ import com.contrastsecurity.plugin.toolwindow.ContrastToolWindow;
 import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.Presentation;
+import com.intellij.openapi.actionSystem.ex.ActionUtil;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.content.Content;
@@ -58,9 +60,11 @@ public class Action extends AnAction {
   }
 
   @Override
-  public boolean displayTextInToolbar() {
-    return true;
+  public void update(@NotNull AnActionEvent e) {
+    Presentation presentation = e.getPresentation();
+    presentation.putClientProperty(ActionUtil.SHOW_TEXT_IN_TOOLBAR, true);
   }
+
 
   @Override
   public @NotNull ActionUpdateThread getActionUpdateThread() {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -92,5 +92,5 @@
         <iw.actionProvider implementation="com.contrastsecurity.plugin.inspection.EditorWidgetActionProvider"/>
     </extensions>
     <!-- Plugin compatibility range -->
-    <idea-version since-build="242.20224.300" until-build="243.*"/>
+    <idea-version since-build="243.21565.193" until-build="243.*"/>
 </idea-plugin>


### PR DESCRIPTION
Updated the plugin compatibility range from 242 to 243 and above, just to have delegated package which is deployment ready for market place.

Supported versions : IntelliJ IC 243 and above, IntelliJ IU 243 and above
Not Supported version : IntelliJ IC 242 or less than 243, IntelliJ IU 242 or less than 243

Tested in the following platform from developer end.
OS: Ubuntu

IntelliJ IC 243
IntelliJ IU 243